### PR TITLE
Añadir GitHub Actions #27

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,33 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "develop", "main" ]
+  pull_request:
+    branches: [ "develop", "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run lint
+    - run: npm run format
+    - run: npm run test --if-present
+    

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "morgan": "^1.10.0",
         "passport": "^0.6.0",
         "passport-discord": "^0.1.4",
+        "passport-github2": "^0.1.12",
         "winston": "^3.10.0"
       },
       "devDependencies": {
@@ -41,7 +42,8 @@
         "@types/node": "^20.4.5",
         "@types/passport": "^1.0.12",
         "@types/passport-discord": "^0.1.7",
-        "@typescript-eslint/eslint-plugin": "^5.62.0",
+        "@types/passport-github2": "^1.2.5",
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^8.0.1",
         "eslint-config-prettier": "^8.3.0",
@@ -884,6 +886,17 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@types/passport-discord/-/passport-discord-0.1.8.tgz",
       "integrity": "sha512-kyi9O7jMXiSBo3W6HvWxfs+9VivjrzW8nH3TaEKs/8T01tAo1vHbOLpg0gBC6sLyWcgSBiU+KRbLtbDwCCNB4Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
+      }
+    },
+    "node_modules/@types/passport-github2": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/passport-github2/-/passport-github2-1.2.5.tgz",
+      "integrity": "sha512-+WLyrd8JPsCxroK34EjegR0j3FMxp6wqB9cw/sRCFkWT9qic1dymAn021gr336EpyjzdhjUd2KKrqyxvdFSvOA==",
       "dev": true,
       "dependencies": {
         "@types/express": "*",
@@ -4218,6 +4231,17 @@
       "integrity": "sha512-VJWPYqSOmh7SaCLw/C+k1ZqCzJnn2frrmQRx1YrcPJ3MQ+Oa31XclbbmqFICSvl8xv3Fqd6YWQ4H4p1MpIN9rA==",
       "dependencies": {
         "passport-oauth2": "^1.5.0"
+      }
+    },
+    "node_modules/passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/passport-oauth2": {


### PR DESCRIPTION
Se añade un workflow template generado por GitHub para la verificación de formato, el lint y el test cada vez que se haga un push o un pull request hacia las branchs `develop` y `main`. El ambiente de pruebas está en dos versiones de node: 18 y 20.

Dado que todavía no hay tests, le añadí la flag `--if-present` al comando de test.